### PR TITLE
package/glibc: request hardware floating-point linkage on ARM32

### DIFF
--- a/package/glibc/2.17-20-g05573613e0b4f99f2718f62957c77d5842df3592/0018-crti.S-force-TAG_ABI_VFP_args_attribute_on_arm.patch
+++ b/package/glibc/2.17-20-g05573613e0b4f99f2718f62957c77d5842df3592/0018-crti.S-force-TAG_ABI_VFP_args_attribute_on_arm.patch
@@ -4,7 +4,7 @@
  #include <libc-symbols.h>
  #include <sysdep.h>
  
-+#ifdef __arm__
++#if defined __arm__ && defined HAVE_ARM_PCS_VFP
 +// Force the Tag_ABI_VFP_args build attribute to hard.
 +// This was previously missing in shared libraries created with clang's lld linker.
 +// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.100068_0607_00_en/zea1485538620282.html

--- a/package/glibc/2.17-20-g05573613e0b4f99f2718f62957c77d5842df3592/0018-crti.S-force-TAG_ABI_VFP_args_attribute_on_arm.patch
+++ b/package/glibc/2.17-20-g05573613e0b4f99f2718f62957c77d5842df3592/0018-crti.S-force-TAG_ABI_VFP_args_attribute_on_arm.patch
@@ -1,0 +1,16 @@
+--- a/ports/sysdeps/arm/crti.S	2014-06-04 01:43:08.000000000 +0200
++++ b/ports/sysdeps/arm/crti.S	2020-03-20 18:28:29.096747744 +0100
+@@ -41,6 +41,13 @@
+ #include <libc-symbols.h>
+ #include <sysdep.h>
+ 
++#ifdef __arm__
++// Force the Tag_ABI_VFP_args build attribute to hard.
++// This was previously missing in shared libraries created with clang's lld linker.
++// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.100068_0607_00_en/zea1485538620282.html
++.eabi_attribute Tag_ABI_VFP_args, 1
++#endif
++
+ #ifndef PREINIT_FUNCTION
+ # define PREINIT_FUNCTION __gmon_start__
+ #endif


### PR DESCRIPTION
Using the buildroot SDK for cross compilation to ARM32 resulted in shared libraries that were missing the Tag_ABI_VFP_args file attribute and so could not be loaded. This only happened when using clang's lld linker which however is preferredly used for cross compilation by the unity editor.
This CL forces the Tag_ABI_VFP_args file attribute into binaries - specifically only on ARM32 - by adapting crti.o from glibc.